### PR TITLE
Use parallel instead of monad-par

### DIFF
--- a/statistics.cabal
+++ b/statistics.cabal
@@ -120,14 +120,13 @@ library
                , binary                  >= 0.5.1.0
                , primitive               >= 0.3
                , dense-linear-algebra    >= 0.1 && <0.2
+               , parallel                >= 3.2.2.0 && <3.3
                , vector                  >= 0.10
                , vector-algorithms       >= 0.4
                , vector-th-unbox
                , vector-binary-instances >= 0.2.1
                , data-default-class      >= 0.1.2
-  if !impl(ghcjs)
-    build-depends:
-      monad-par               >= 0.3.4
+
   -- Older GHC
   if impl(ghc < 7.6)
     build-depends:


### PR DESCRIPTION
The commit drops five packages:

```diff
-abstract-deque-0.3 lib
-abstract-par-0.3.3 lib
-cereal-0.5.8.2 lib
-monad-par-0.3.5 lib
-monad-par-extras-0.3.3 lib
```

(`parallel` is a dependency of `monad-par`).

So this seems to be a pure win. This also helps with `mtl-2.3`
compatibility in a short term. See https://github.com/ekmett/lens/issues/1007#issuecomment-1122703286