### PR TITLE
exponential distribution:  Fix fromSample.

### DIFF
--- a/Statistics/Distribution/Exponential.hs
+++ b/Statistics/Distribution/Exponential.hs
@@ -142,5 +142,5 @@ errMsg l = "Statistics.Distribution.Exponential.exponential: scale parameter mus
 instance D.FromSample ExponentialDistribution Double where
   fromSample xs
     | G.null xs       = Nothing
-    | G.all (>= 0) xs = Nothing
+    | G.any (< 0) xs  = Nothing
     | otherwise       = Just $! ED (S.mean xs)


### PR DESCRIPTION
fromSample had a typo causing it to reject all valid samples (those contaning only nonnegative values), and accept only invalid ones.