### PR TITLE
Fix fromSample for exponential distribution, take 2.

### DIFF
--- a/Statistics/Distribution.hs
+++ b/Statistics/Distribution.hs
@@ -171,9 +171,9 @@ class (DiscreteDistr d, ContGen d) => DiscreteGen d where
 -- | Estimate distribution from sample. First parameter in sample is
 --   distribution type and second is element type.
 class FromSample d a where
-  -- | Estimate distribution from sample. Returns 'Nothing' is there's
-  --   not enough data to estimate, or if no usable fit results from the
-  --   method used, e.g., the estimated distribution parameters would be
+  -- | Estimate distribution from sample. Returns 'Nothing' if there is
+  --   not enough data, or if no usable fit results from the method
+  --   used, e.g., the estimated distribution parameters would be
   --   invalid or inaccurate.
   fromSample :: G.Vector v a => v a -> Maybe d
 

--- a/Statistics/Distribution.hs
+++ b/Statistics/Distribution.hs
@@ -171,10 +171,10 @@ class (DiscreteDistr d, ContGen d) => DiscreteGen d where
 -- | Estimate distribution from sample. First parameter in sample is
 --   distribution type and second is element type.
 class FromSample d a where
-  -- | Estimate distribution from sample. Returns nothing is there's
-  --   not enough data to estimate or sample clearly doesn't come from
-  --   distribution in question. For example if there's negative
-  --   samples in exponential distribution.
+  -- | Estimate distribution from sample. Returns 'Nothing' is there's
+  --   not enough data to estimate, or if no usable fit results from the
+  --   method used, e.g., the estimated distribution parameters would be
+  --   invalid or inaccurate.
   fromSample :: G.Vector v a => v a -> Maybe d
 
 

--- a/Statistics/Distribution/Exponential.hs
+++ b/Statistics/Distribution/Exponential.hs
@@ -33,7 +33,6 @@ import GHC.Generics                    (Generic)
 import Numeric.SpecFunctions           (log1p,expm1)
 import Numeric.MathFunctions.Constants (m_neg_inf)
 import qualified System.Random.MWC.Distributions as MWC
-import qualified Data.Vector.Generic as G
 
 import qualified Statistics.Distribution         as D
 import qualified Statistics.Sample               as S
@@ -136,11 +135,9 @@ exponentialE l
 errMsg :: Double -> String
 errMsg l = "Statistics.Distribution.Exponential.exponential: scale parameter must be positive. Got " ++ show l
 
--- | Create exponential distribution from sample. Returns @Nothing@ if
---   sample is empty or contains negative elements. No other tests are
---   made to check whether it truly is exponential.
+-- | Create exponential distribution from sample.  Estimates the rate
+--   with the maximum likelihood estimator, which is biased. Returns
+--   @Nothing@ if the sample mean does not exist or is not positive.
 instance D.FromSample ExponentialDistribution Double where
-  fromSample xs
-    | G.null xs       = Nothing
-    | G.all (>= 0) xs = Just $! ED (S.mean xs)
-    | otherwise       = Nothing
+  fromSample xs = let m = S.mean xs
+                  in  if m > 0 then Just (ED (1/m)) else Nothing

--- a/Statistics/Distribution/Laplace.hs
+++ b/Statistics/Distribution/Laplace.hs
@@ -151,9 +151,9 @@ errMsg :: Double -> Double -> String
 errMsg _ s = "Statistics.Distribution.Laplace.laplace: scale parameter must be positive. Got " ++ show s
 
 
--- | Create Laplace distribution from sample. No tests are made to
---   check whether it truly is Laplace. Location of distribution
---   estimated as median of sample.
+-- | Create Laplace distribution from sample.  The location is estimated
+--   as the median of the sample, and the scale as the mean absolute
+--   deviation of the median.
 instance D.FromSample LaplaceDistribution Double where
   fromSample xs
     | G.null xs = Nothing


### PR DESCRIPTION
Hi,

Unfortunately, my previous fixes for exponential distribution of fromSample were not enough.

# Summary of problems

For one thing, the formula is mean in that it used `(ED (mean xs))`, but ED takes the rate, not the mean, so it should be `(ED (1/(mean xs)))` instead.

Second, the requirement that all the data point must be non-negative to fit an exponential distribution is counter-productive.

# Why allow negative values?

If the data points are a noisy, some of them can end up being negative, even if the underlying distribution is generally exponential.  It would be better if `fromSample` still worked for such noisy samples, rather than gratuitously returning `Nothing` instead.  Remember that in practice, pretty much all data is noisy to some extent.

I think that in general, `fromSample` should return a non-`Nothing` fit for any distribution if doing so is possible, i.e., will result in a reasonable fit with valid distribution parameters.

In the case of the exponential distribution, this means that the sample mean must exist (i.e., there must be at least data point, no NaN values), and it must be positive.

# Example

As an example, below some sample code that generates exponentially distributed data (rate = 2), and adds some unbiased Gaussian (standard normal) noise on top of it.  Our goal is to recover the underlying exponential distribution from the sample (i.e., to replicate `fromSample`'s task).  Three methods are considered:

1. Simply compute 1/mean.  This corresponds to `fromSample` if it allowed negative values.
2. Discard negative values before doing 1/mean.
3. Clamp negative values to 0 before doing 1/mean.

The discarding and clamping methods above correspond to workarounds if one were to use `fromSample`, but needs to first fix up the data so that `fromSample` does not reject it due to negative values.

For the first method I get the estimated rate `2.03`, for second and third`0.91` and `1.37` respectively.  This illustrates not only that the workarounds are inferior (to the point of uselessness in this case), but also that the negative values contribute information on the true value of the rate.

```hs
-- Generate a noisy sample.

import Control.Monad
import qualified Data.Vector.Unboxed as V
import System.Random
import System.Random.Stateful

import Statistics.Distribution
import Statistics.Distribution.Exponential
import Statistics.Distribution.Normal
import Statistics.Sample as S

main = do
    let g = mkStdGen 10
    let l = 100000          -- number of samples

    -- Generate samples on base distribution
    let de = exponential 2
    let (se, g') = runStateGen g $ V.replicateM l . genContVar de

    -- Generate noise samples
    let dn = normalDistr 0 1
    let sn = if True then
                runStateGen_ g' $ V.replicateM l . genContVar dn
             else
                V.replicate l 0

    -- Add the two to get our noisy distribution
    let v = V.map (\ (x, y) -> x + y) $ V.zip se sn

    -- Estimate the exponential with different methods.
    putStrLn $ "The first few samples: " ++ show (V.take 10 v)
    putStrLn $ "Parameter fit: " ++ show (1/(S.mean v))
    putStrLn $ "fromSample: " ++ show ((fromSample v)::Maybe ExponentialDistribution)
    putStrLn $ "\nAlternatives:"
    let v' = V.filter (>0) v
    putStrLn $ "Parameter fit obtained by discarding negative values: " ++ show (1/(S.mean v'))
    let v'' = V.map (\ x -> if x > 0 then x else 0) v
    putStrLn $ "Parameter fit obtained by clamping negative values: " ++ show (1/(S.mean v''))
```