### PR TITLE
Improve accuracy of Geometric Distribution

### DIFF
--- a/Statistics/Distribution/Geometric.hs
+++ b/Statistics/Distribution/Geometric.hs
@@ -81,6 +81,7 @@ instance D.Distribution GeometricDistribution where
 instance D.DiscreteDistr GeometricDistribution where
     probability (GD s) n
       | n < 1     = 0
+      | s >= 0.5  = s * (1 - s)^(n - 1)
       | otherwise = s * (exp $ log1p (-s) * (fromIntegral n - 1))
     logProbability (GD s) n
        | n < 1     = m_neg_inf
@@ -119,14 +120,18 @@ cumulative (GD s) x
   | x < 1        = 0
   | isInfinite x = 1
   | isNaN      x = error "Statistics.Distribution.Geometric.cumulative: NaN input"
-  | otherwise    = negate $ expm1 $ fromIntegral (floor x :: Int) * log1p (-s)
+  | s >= 0.5     = 1 - (1 - s)^k
+  | otherwise    = negate $ expm1 $ fromIntegral k * log1p (-s)
+    where k = floor x :: Int
 
 complCumulative :: GeometricDistribution -> Double -> Double
 complCumulative (GD s) x
   | x < 1        = 1
   | isInfinite x = 0
   | isNaN      x = error "Statistics.Distribution.Geometric.complCumulative: NaN input"
-  | otherwise    = exp $ fromIntegral (floor x :: Int) * log1p (-s)
+  | s >= 0.5     = (1 - s)^k
+  | otherwise    = exp $ fromIntegral k * log1p (-s)
+    where k = floor x :: Int
 
 
 -- | Create geometric distribution.

--- a/Statistics/Distribution/Geometric.hs
+++ b/Statistics/Distribution/Geometric.hs
@@ -81,10 +81,10 @@ instance D.Distribution GeometricDistribution where
 instance D.DiscreteDistr GeometricDistribution where
     probability (GD s) n
       | n < 1     = 0
-      | otherwise = s * (1-s) ** (fromIntegral n - 1)
+      | otherwise = s * (exp $ log1p (-s) * (fromIntegral n - 1))
     logProbability (GD s) n
        | n < 1     = m_neg_inf
-       | otherwise = log s + log (1-s) * (fromIntegral n - 1)
+       | otherwise = log s + log1p (-s) * (fromIntegral n - 1)
 
 
 instance D.Mean GeometricDistribution where
@@ -104,7 +104,7 @@ instance D.Entropy GeometricDistribution where
   entropy (GD s)
     | s == 0 = m_pos_inf
     | s == 1 = 0
-    | otherwise = negate $ (s * log s + (1-s) * log (1-s)) / s
+    | otherwise = -(s * log s + (1-s) * log1p (-s)) / s
 
 instance D.MaybeEntropy GeometricDistribution where
   maybeEntropy = Just . D.entropy

--- a/Statistics/Distribution/Geometric.hs
+++ b/Statistics/Distribution/Geometric.hs
@@ -39,7 +39,7 @@ import Data.Aeson          (FromJSON(..), ToJSON, Value(..), (.:))
 import Data.Binary         (Binary(..))
 import Data.Data           (Data, Typeable)
 import GHC.Generics        (Generic)
-import Numeric.MathFunctions.Constants (m_pos_inf, m_neg_inf)
+import Numeric.MathFunctions.Constants (m_neg_inf)
 import Numeric.SpecFunctions           (log1p,expm1)
 import qualified System.Random.MWC.Distributions as MWC
 
@@ -102,7 +102,6 @@ instance D.MaybeVariance GeometricDistribution where
 
 instance D.Entropy GeometricDistribution where
   entropy (GD s)
-    | s == 0 = m_pos_inf
     | s == 1 = 0
     | otherwise = -(s * log s + (1-s) * log1p (-s)) / s
 
@@ -126,7 +125,7 @@ complCumulative :: GeometricDistribution -> Double -> Double
 complCumulative (GD s) x
   | x < 1        = 1
   | isInfinite x = 0
-  | isNaN      x = error "Statistics.Distribution.Geometric.cumulative: NaN input"
+  | isNaN      x = error "Statistics.Distribution.Geometric.complCumulative: NaN input"
   | otherwise    = exp $ fromIntegral (floor x :: Int) * log1p (-s)
 
 
@@ -139,11 +138,11 @@ geometric x = maybe (error $ errMsg x) id $ geometricE x
 geometricE :: Double                -- ^ Success rate
            -> Maybe GeometricDistribution
 geometricE x
-  | x >= 0 && x <= 1 = Just (GD x)
+  | x > 0 && x <= 1  = Just (GD x)
   | otherwise        = Nothing
 
 errMsg :: Double -> String
-errMsg x = "Statistics.Distribution.Geometric.geometric: probability must be in [0,1] range. Got " ++ show x
+errMsg x = "Statistics.Distribution.Geometric.geometric: probability must be in (0,1] range. Got " ++ show x
 
 
 ----------------------------------------------------------------
@@ -215,8 +214,8 @@ geometric0 x = maybe (error $ errMsg0 x) id $ geometric0E x
 geometric0E :: Double                -- ^ Success rate
             -> Maybe GeometricDistribution0
 geometric0E x
-  | x >= 0 && x <= 1 = Just (GD0 x)
+  | x > 0 && x <= 1  = Just (GD0 x)
   | otherwise        = Nothing
 
 errMsg0 :: Double -> String
-errMsg0 x = "Statistics.Distribution.Geometric.geometric0: probability must be in [0,1] range. Got " ++ show x
+errMsg0 x = "Statistics.Distribution.Geometric.geometric0: probability must be in (0,1] range. Got " ++ show x

--- a/tests/Tests/Orphanage.hs
+++ b/tests/Tests/Orphanage.hs
@@ -44,9 +44,9 @@ instance QC.Arbitrary GammaDistribution where
 instance QC.Arbitrary BetaDistribution where
   arbitrary = betaDistr <$> QC.choose (1e-3,10) <*> QC.choose (1e-3,10)
 instance QC.Arbitrary GeometricDistribution where
-  arbitrary = geometric <$> QC.choose (0,1)
+  arbitrary = geometric <$> QC.choose (1e-10,1)
 instance QC.Arbitrary GeometricDistribution0 where
-  arbitrary = geometric0 <$> QC.choose (0,1)
+  arbitrary = geometric0 <$> QC.choose (1e-10,1)
 instance QC.Arbitrary HypergeometricDistribution where
   arbitrary = do l <- QC.choose (1,20)
                  m <- QC.choose (0,l)


### PR DESCRIPTION
The probability mass function of the geometric distribution had some accuracy problems.  Example:
```
ghci> da = (geometric (35 / 65536))
ghci> pa = Statistics.Distribution.probability da 106822
ghci> pa
8.812340833341934e-29
```
The correct answer in this case is `8.812340833326208e-29`.

Problematic expressions are of the form `log (1-x)` for small `x`; replace them by `log1p (-x)`.

Also exclude the invalid parameter choice p = 0.