### PR TITLE
Typo in Statistics.Types

### DIFF
--- a/Statistics/Types.hs
+++ b/Statistics/Types.hs
@@ -299,6 +299,7 @@ errMkPValue = "Statistics.Types.mkPValue: probability is out if [0,1] range"
 -- >                       , confIntUDX = 6
 -- >                       , confIntCL  = cl95
 -- >                       }
+-- >          }
 --
 -- Prior to statistics 0.14 @Estimate@ data type used following definition:
 --


### PR DESCRIPTION
Hi, just saw a typo when reading through the statistics.types docs :)