### PR TITLE
Expose sample statistics function as Folds from the foldl package

### DIFF
--- a/Statistics/Sample/Fold.hs
+++ b/Statistics/Sample/Fold.hs
@@ -1,0 +1,512 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- |
+-- Module    : Statistics.Sample
+-- Copyright : (c) 2008 Don Stewart, 2009 Bryan O'Sullivan
+-- License   : BSD3
+--
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : portable
+--
+-- Commonly used sample statistics, also known as descriptive
+-- statistics.
+
+module Statistics.Sample.Fold
+    (
+    -- * Types
+      Sample
+    , WeightedSample
+    -- * Descriptive functions
+    , range
+
+    -- * Statistics of location
+    , expectation
+    , mean
+    , welfordMean
+    , meanWeighted
+    , harmonicMean
+    , geometricMean
+
+    -- * Statistics of dispersion
+    -- $variance
+
+    -- ** Functions over central moments
+    , centralMoment
+    , centralMoments
+    , skewness
+    , kurtosis
+
+    -- ** Two-pass functions (numerically robust)
+    -- $robust
+    , variance
+    , varianceUnbiased
+    , meanVariance
+    , meanVarianceUnb
+    , stdDev
+    , varianceWeighted
+    , stdErrMean
+
+    -- ** Single-pass functions (faster, less safe)
+    -- $cancellation
+    , fastVariance
+    , fastVarianceUnbiased
+    , fastStdDev
+
+    -- * Joint distributions
+    , covariance
+    , correlation
+    , covariance2
+    , correlation2
+    , pair
+    -- * References
+    -- $references
+    ) where
+
+import Statistics.Function (square)
+import Statistics.Sample.Internal (robustSumVar, sum)
+import Statistics.Types.Internal  (Sample,WeightedSample)
+import qualified Data.Vector as V
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Unboxed as U
+import Numeric.Sum (kbn, Summation(zero,add), KBNSum)
+
+import qualified Control.Foldl as F
+
+-- Operator ^ will be overridden
+import Prelude hiding ((^), sum)
+
+-- | /O(n)/ Range. The difference between the largest and smallest
+-- elements of a sample.
+range :: F.Fold Double Double
+range = maximum' - minimum'
+{-# INLINE range #-}
+
+maximum' :: F.Fold Double Double
+maximum' = F.Fold max (-1/0 :: Double) id where
+minimum' :: F.Fold Double Double
+minimum' = F.Fold min ( 1/0 :: Double) id where
+
+kbnSum' :: F.Fold Double KBNSum
+kbnSum' = F.Fold add zero id
+
+kbnSum :: F.Fold Double Double
+kbnSum = fmap kbn kbnSum'
+
+
+-- | Compute expectation of function over for sample.
+expectation :: (a -> Double) -> F.Fold a Double
+expectation f = F.premap f kbnSum / F.genericLength
+{-# INLINE expectation #-}
+
+-- | Arithmetic mean.  This uses Kahan-Babuška-Neumaier
+-- summation, so is more accurate than 'welfordMean' unless the input
+-- values are very large. This function is not subject to stream
+-- fusion.
+mean :: F.Fold Double Double
+mean = kbnSum / F.genericLength
+
+-- | Arithmetic mean.  This uses Welford's algorithm to provide
+-- numerical stability, using a single pass over the sample data.
+--
+-- Compared to 'mean', this loses a surprising amount of precision
+-- unless the inputs are very large.
+welfordMean :: F.Fold Double Double
+welfordMean = F.Fold go (T 0 0) fini
+  where
+    fini (T a _) = a
+    go (T m n) x = T m' n'
+        where m' = m + (x - m) / fromIntegral n'
+              n' = n + 1
+
+
+-- | Arithmetic mean for weighted sample. It uses a single-pass
+-- algorithm analogous to the one used by 'welfordMean'.
+meanWeighted :: F.Fold (Double,Double) Double
+meanWeighted = F.Fold go (V 0 0) fini
+    where
+      fini (V a _) = a
+      go (V m w) (x,xw) = V m' w'
+          where m' | w' == 0   = 0
+                   | otherwise = m + xw * (x - m) / w'
+                w' = w + xw
+{-# INLINE meanWeighted #-}
+
+-- | Harmonic mean.  This algorithm performs a single pass over
+-- the sample.
+harmonicMean :: F.Fold Double Double
+harmonicMean = F.Fold go (T 0 0) fini
+  where
+    fini (T b a) = fromIntegral a / b
+    go (T x y) n = T (x + (1/n)) (y+1)
+{-# INLINE harmonicMean #-}
+
+-- | Geometric mean of a sample containing no negative values.
+geometricMean :: F.Fold Double Double
+geometricMean = fmap exp (expectation log)
+{-# INLINE geometricMean #-}
+
+-- | Compute the /k/th central moment of a sample.  The central moment
+-- is also known as the moment about the mean.
+--
+-- This function performs two passes over the sample, so is not subject
+-- to stream fusion.
+--
+-- For samples containing many values very close to the mean, this
+-- function is subject to inaccuracy due to catastrophic cancellation.
+centralMoment :: Int
+              -> Double -- ^ mean
+              -> F.Fold Double Double
+centralMoment a m
+    | a < 0  = error "Statistics.Sample.centralMoment: negative input"
+    | a == 0 = pure 1
+    | a == 1 = pure 0
+    | otherwise = expectation go
+  where
+    go x = (x-m) ^ a
+    -- m    = mean xs
+--
+
+-- | Compute the /k/th and /j/th central moments of a sample.
+--
+-- This function performs two passes over the sample, so is not subject
+-- to stream fusion.
+--
+-- For samples containing many values very close to the mean, this
+-- function is subject to inaccuracy due to catastrophic cancellation.
+centralMoments :: (G.Vector v Double) => Int -> Int -> v Double -> (Double, Double)
+centralMoments a b xs
+    | a < 2 || b < 2 = (centralMoment a xs , centralMoment b xs)
+    | otherwise      = fini . G.foldl' go (V 0 0) $ xs
+  where go (V i j) x = V (i + d^a) (j + d^b)
+            where d  = x - m
+        fini (V i j) = (i / n , j / n)
+        m            = mean xs
+        n            = fromIntegral (G.length xs)
+{-# SPECIALIZE
+    centralMoments :: Int -> Int -> U.Vector Double -> (Double, Double) #-}
+{-# SPECIALIZE
+    centralMoments :: Int -> Int -> V.Vector Double -> (Double, Double) #-}
+
+-- | Compute the skewness of a sample. This is a measure of the
+-- asymmetry of its distribution.
+--
+-- A sample with negative skew is said to be /left-skewed/.  Most of
+-- its mass is on the right of the distribution, with the tail on the
+-- left.
+--
+-- > skewness $ U.to [1,100,101,102,103]
+-- > ==> -1.497681449918257
+--
+-- A sample with positive skew is said to be /right-skewed/.
+--
+-- > skewness $ U.to [1,2,3,4,100]
+-- > ==> 1.4975367033335198
+--
+-- A sample's skewness is not defined if its 'variance' is zero.
+--
+-- This function performs two passes over the sample, so is not subject
+-- to stream fusion.
+--
+-- For samples containing many values very close to the mean, this
+-- function is subject to inaccuracy due to catastrophic cancellation.
+skewness :: (G.Vector v Double) => v Double -> Double
+skewness xs = c3 * c2 ** (-1.5)
+    where (c3 , c2) = centralMoments 3 2 xs
+{-# SPECIALIZE skewness :: U.Vector Double -> Double #-}
+{-# SPECIALIZE skewness :: V.Vector Double -> Double #-}
+
+-- | Compute the excess kurtosis of a sample.  This is a measure of
+-- the \"peakedness\" of its distribution.  A high kurtosis indicates
+-- that more of the sample's variance is due to infrequent severe
+-- deviations, rather than more frequent modest deviations.
+--
+-- A sample's excess kurtosis is not defined if its 'variance' is
+-- zero.
+--
+-- This function performs two passes over the sample, so is not subject
+-- to stream fusion.
+--
+-- For samples containing many values very close to the mean, this
+-- function is subject to inaccuracy due to catastrophic cancellation.
+kurtosis :: (G.Vector v Double) => v Double -> Double
+kurtosis xs = c4 / (c2 * c2) - 3
+    where (c4 , c2) = centralMoments 4 2 xs
+{-# SPECIALIZE kurtosis :: U.Vector Double -> Double #-}
+{-# SPECIALIZE kurtosis :: V.Vector Double -> Double #-}
+
+-- $variance
+--
+-- The variance — and hence the standard deviation — of a
+-- sample of fewer than two elements are both defined to be zero.
+
+-- $robust
+--
+-- These functions use the compensated summation algorithm of Chan et
+-- al. for numerical robustness, but require two passes over the
+-- sample data as a result.
+--
+-- Because of the need for two passes, these functions are /not/
+-- subject to stream fusion.
+
+data V = V {-# UNPACK #-} !Double {-# UNPACK #-} !Double
+
+-- | Maximum likelihood estimate of a sample's variance.  Also known
+-- as the population variance, where the denominator is /n/.
+variance :: (G.Vector v Double) => v Double -> Double
+variance samp
+    | n > 1     = robustSumVar (mean samp) samp / fromIntegral n
+    | otherwise = 0
+    where
+      n = G.length samp
+{-# SPECIALIZE variance :: U.Vector Double -> Double #-}
+{-# SPECIALIZE variance :: V.Vector Double -> Double #-}
+
+
+-- | Unbiased estimate of a sample's variance.  Also known as the
+-- sample variance, where the denominator is /n/-1.
+varianceUnbiased :: (G.Vector v Double) => v Double -> Double
+varianceUnbiased samp
+    | n > 1     = robustSumVar (mean samp) samp / fromIntegral (n-1)
+    | otherwise = 0
+    where
+      n = G.length samp
+{-# SPECIALIZE varianceUnbiased :: U.Vector Double -> Double #-}
+{-# SPECIALIZE varianceUnbiased :: V.Vector Double -> Double #-}
+
+-- | Calculate mean and maximum likelihood estimate of variance. This
+-- function should be used if both mean and variance are required
+-- since it will calculate mean only once.
+meanVariance ::  (G.Vector v Double) => v Double -> (Double,Double)
+meanVariance samp
+  | n > 1     = (m, robustSumVar m samp / fromIntegral n)
+  | otherwise = (m, 0)
+    where
+      n = G.length samp
+      m = mean samp
+{-# SPECIALIZE meanVariance :: U.Vector Double -> (Double,Double) #-}
+{-# SPECIALIZE meanVariance :: V.Vector Double -> (Double,Double) #-}
+
+-- | Calculate mean and unbiased estimate of variance. This
+-- function should be used if both mean and variance are required
+-- since it will calculate mean only once.
+meanVarianceUnb :: (G.Vector v Double) => v Double -> (Double,Double)
+meanVarianceUnb samp
+  | n > 1     = (m, robustSumVar m samp / fromIntegral (n-1))
+  | otherwise = (m, 0)
+    where
+      n = G.length samp
+      m = mean samp
+{-# SPECIALIZE meanVarianceUnb :: U.Vector Double -> (Double,Double) #-}
+{-# SPECIALIZE meanVarianceUnb :: V.Vector Double -> (Double,Double) #-}
+
+-- | Standard deviation.  This is simply the square root of the
+-- unbiased estimate of the variance.
+stdDev :: (G.Vector v Double) => v Double -> Double
+stdDev = sqrt . varianceUnbiased
+{-# SPECIALIZE stdDev :: U.Vector Double -> Double #-}
+{-# SPECIALIZE stdDev :: V.Vector Double -> Double #-}
+
+-- | Standard error of the mean. This is the standard deviation
+-- divided by the square root of the sample size.
+stdErrMean :: (G.Vector v Double) => v Double -> Double
+stdErrMean samp = stdDev samp / (sqrt . fromIntegral . G.length) samp
+{-# SPECIALIZE stdErrMean :: U.Vector Double -> Double #-}
+{-# SPECIALIZE stdErrMean :: V.Vector Double -> Double #-}
+
+robustSumVarWeighted :: (G.Vector v (Double,Double)) => v (Double,Double) -> V
+robustSumVarWeighted samp = G.foldl' go (V 0 0) samp
+    where
+      go (V s w) (x,xw) = V (s + xw*d*d) (w + xw)
+          where d = x - m
+      m = meanWeighted samp
+{-# INLINE robustSumVarWeighted #-}
+
+-- | Weighted variance. This is biased estimation.
+varianceWeighted :: (G.Vector v (Double,Double)) => v (Double,Double) -> Double
+varianceWeighted samp
+    | G.length samp > 1 = fini $ robustSumVarWeighted samp
+    | otherwise         = 0
+    where
+      fini (V s w) = s / w
+{-# SPECIALIZE varianceWeighted :: U.Vector (Double,Double) -> Double #-}
+{-# SPECIALIZE varianceWeighted :: V.Vector (Double,Double) -> Double #-}
+
+-- $cancellation
+--
+-- The functions prefixed with the name @fast@ below perform a single
+-- pass over the sample data using Knuth's algorithm. They usually
+-- work well, but see below for caveats. These functions are subject
+-- to array fusion.
+--
+-- /Note/: in cases where most sample data is close to the sample's
+-- mean, Knuth's algorithm gives inaccurate results due to
+-- catastrophic cancellation.
+
+fastVar :: (G.Vector v Double) => v Double -> T1
+fastVar = G.foldl' go (T1 0 0 0)
+  where
+    go (T1 n m s) x = T1 n' m' s'
+      where n' = n + 1
+            m' = m + d / fromIntegral n'
+            s' = s + d * (x - m')
+            d  = x - m
+
+-- | Maximum likelihood estimate of a sample's variance.
+fastVariance :: (G.Vector v Double) => v Double -> Double
+fastVariance = fini . fastVar
+  where fini (T1 n _m s)
+          | n > 1     = s / fromIntegral n
+          | otherwise = 0
+{-# INLINE fastVariance #-}
+
+-- | Unbiased estimate of a sample's variance.
+fastVarianceUnbiased :: (G.Vector v Double) => v Double -> Double
+fastVarianceUnbiased = fini . fastVar
+  where fini (T1 n _m s)
+          | n > 1     = s / fromIntegral (n - 1)
+          | otherwise = 0
+{-# INLINE fastVarianceUnbiased #-}
+
+-- | Standard deviation.  This is simply the square root of the
+-- maximum likelihood estimate of the variance.
+fastStdDev :: (G.Vector v Double) => v Double -> Double
+fastStdDev = sqrt . fastVariance
+{-# INLINE fastStdDev #-}
+
+-- | Covariance of sample of pairs. For empty sample it's set to
+--   zero
+covariance :: (G.Vector v (Double,Double))
+           => v (Double,Double)
+           -> Double
+covariance xy
+  | n == 0    = 0
+  | otherwise = expectation (\(x,y) -> (x - muX)*(y - muY)) xy
+  where
+    n   = G.length xy
+    muX = expectation fst xy
+    muY = expectation snd xy
+{-# SPECIALIZE covariance :: U.Vector (Double,Double) -> Double #-}
+{-# SPECIALIZE covariance :: V.Vector (Double,Double) -> Double #-}
+
+-- | Correlation coefficient for sample of pairs. Also known as
+--   Pearson's correlation. For empty sample it's set to zero.
+correlation :: (G.Vector v (Double,Double))
+           => v (Double,Double)
+           -> Double
+correlation xy
+  | n == 0    = 0
+  | otherwise = cov / sqrt (varX * varY)
+  where
+    n    = G.length xy
+    muX  = expectation (\(x,_) -> x) xy
+    muY  = expectation (\(_,y) -> y) xy
+    varX = expectation (\(x,_) -> square (x - muX))    xy
+    varY = expectation (\(_,y) -> square (y - muY))    xy
+    cov  = expectation (\(x,y) -> (x - muX)*(y - muY)) xy
+{-# SPECIALIZE correlation :: U.Vector (Double,Double) -> Double #-}
+{-# SPECIALIZE correlation :: V.Vector (Double,Double) -> Double #-}
+
+
+-- | Covariance of two samples. Both vectors must be of the same
+--   length. If both are empty it's set to zero
+covariance2 :: (G.Vector v Double)
+           => v Double
+           -> v Double
+           -> Double
+covariance2 xs ys
+  | nx /= ny  = error $ "Statistics.Sample.covariance2: both samples must have same length"
+  | nx == 0   = 0
+  | otherwise = sum (G.zipWith (\x y -> (x - muX)*(y - muY)) xs ys)
+              / fromIntegral nx
+  where
+    nx  = G.length xs
+    ny  = G.length ys
+    muX = mean xs
+    muY = mean ys
+{-# SPECIALIZE covariance2 :: U.Vector Double -> U.Vector Double -> Double #-}
+{-# SPECIALIZE covariance2 :: V.Vector Double -> V.Vector Double -> Double #-}
+
+-- | Correlation coefficient for two samples. Both vector must have
+--   same length Also known as Pearson's correlation. For empty sample
+--   it's set to zero.
+correlation2 :: (G.Vector v Double)
+             => v Double
+             -> v Double
+             -> Double
+correlation2 xs ys
+  | nx /= ny  = error $ "Statistics.Sample.correlation2: both samples must have same length"
+  | nx == 0   = 0
+  | otherwise = cov / sqrt (varX * varY)
+  where
+    nx         = G.length xs
+    ny         = G.length ys
+    (muX,varX) = meanVariance xs
+    (muY,varY) = meanVariance ys
+    cov = sum (G.zipWith (\x y -> (x - muX)*(y - muY)) xs ys)
+        / fromIntegral nx
+{-# SPECIALIZE correlation2 :: U.Vector Double -> U.Vector Double -> Double #-}
+{-# SPECIALIZE correlation2 :: V.Vector Double -> V.Vector Double -> Double #-}
+
+
+-- | Pair two samples. It's like 'G.zip' but requires that both
+--   samples have equal size.
+pair :: (G.Vector v a, G.Vector v b, G.Vector v (a,b)) => v a -> v b -> v (a,b)
+pair va vb
+  | G.length va == G.length vb = G.zip va vb
+  | otherwise = error "Statistics.Sample.pair: vector must have same length"
+{-# INLINE pair #-}
+
+------------------------------------------------------------------------
+-- Helper code. Monomorphic unpacked accumulators.
+
+-- (^) operator from Prelude is just slow.
+(^) :: Double -> Int -> Double
+x ^ 1 = x
+x ^ n = x * (x ^ (n-1))
+{-# INLINE (^) #-}
+
+-- don't support polymorphism, as we can't get unboxed returns if we use it.
+data T = T {-# UNPACK #-}!Double {-# UNPACK #-}!Int
+
+data T1 = T1 {-# UNPACK #-}!Int {-# UNPACK #-}!Double {-# UNPACK #-}!Double
+
+{-
+
+Consider this core:
+
+with data T a = T !a !Int
+
+$wfold :: Double#
+               -> Int#
+               -> Int#
+               -> (# Double, Int# #)
+
+and without,
+
+$wfold :: Double#
+               -> Int#
+               -> Int#
+               -> (# Double#, Int# #)
+
+yielding to boxed returns and heap checks.
+
+-}
+
+-- $references
+--
+-- * Chan, T. F.; Golub, G.H.; LeVeque, R.J. (1979) Updating formulae
+--   and a pairwise algorithm for computing sample
+--   variances. Technical Report STAN-CS-79-773, Department of
+--   Computer Science, Stanford
+--   University. <ftp://reports.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf>
+--
+-- * Knuth, D.E. (1998) The art of computer programming, volume 2:
+--   seminumerical algorithms, 3rd ed., p. 232.
+--
+-- * Welford, B.P. (1962) Note on a method for calculating corrected
+--   sums of squares and products. /Technometrics/
+--   4(3):419&#8211;420. <http://www.jstor.org/stable/1266577>
+--
+-- * West, D.H.D. (1979) Updating mean and variance estimates: an
+--   improved method. /Communications of the ACM/
+--   22(9):532&#8211;535. <http://doi.acm.org/10.1145/359146.359153>

--- a/Statistics/Sample/Fold.hs
+++ b/Statistics/Sample/Fold.hs
@@ -11,69 +11,77 @@
 -- Commonly used sample statistics, also known as descriptive
 -- statistics.
 
-module Statistics.Sample.Fold
-    (
-    -- * Types
-      Sample
-    , WeightedSample
-    -- * Descriptive functions
-    , range
+module Statistics.Sample.Fold where
+    -- (
+    -- -- * Types
+    --   Sample
+    -- , WeightedSample
+    -- -- * Descriptive functions
+    -- , range
 
-    -- * Statistics of location
-    , expectation
-    , mean
-    , welfordMean
-    , meanWeighted
-    , harmonicMean
-    , geometricMean
+    -- -- * Statistics of location
+    -- , expectation
+    -- , mean
+    -- , welfordMean
+    -- , meanWeighted
+    -- , harmonicMean
+    -- , geometricMean
 
-    -- * Statistics of dispersion
-    -- $variance
+    -- -- * Statistics of dispersion
+    -- -- $variance
 
-    -- ** Functions over central moments
-    , centralMoment
-    , centralMoments
-    , skewness
-    , kurtosis
+    -- -- ** Functions over central moments
+    -- , centralMoment
+    -- , centralMoments
+    -- , skewness
+    -- , kurtosis
 
-    -- ** Two-pass functions (numerically robust)
-    -- $robust
-    , variance
-    , varianceUnbiased
-    , meanVariance
-    , meanVarianceUnb
-    , stdDev
-    , varianceWeighted
-    , stdErrMean
+    -- -- ** Two-pass functions (numerically robust)
+    -- -- $robust
+    -- , variance
+    -- , varianceUnbiased
+    -- -- , meanVariance
+    -- -- , meanVarianceUnb
+    -- , stdDev
+    -- , varianceWeighted
+    -- , stdErrMean
 
-    -- ** Single-pass functions (faster, less safe)
-    -- $cancellation
-    , fastVariance
-    , fastVarianceUnbiased
-    , fastStdDev
+    -- -- ** Single-pass functions (faster, less safe)
+    -- -- $cancellation
+    -- , fastVariance
+    -- , fastVarianceUnbiased
+    -- , fastStdDev
 
-    -- * Joint distributions
-    , covariance
-    , correlation
-    , covariance2
-    , correlation2
-    , pair
-    -- * References
-    -- $references
-    ) where
+    -- -- * Joint distributions
+    -- , covariance
+    -- , correlation
+    -- , covariance2
+    -- , correlation2
+    -- , pair
+    -- -- * References
+    -- -- $references
+    -- ) where
 
 import Statistics.Function (square)
-import Statistics.Sample.Internal (robustSumVar, sum)
-import Statistics.Types.Internal  (Sample,WeightedSample)
-import qualified Data.Vector as V
-import qualified Data.Vector.Generic as G
-import qualified Data.Vector.Unboxed as U
+-- import Statistics.Sample.Internal (robustSumVar, sum)
+-- import Statistics.Types.Internal  (Sample,WeightedSample)
 import Numeric.Sum (kbn, Summation(zero,add), KBNSum)
 
 import qualified Control.Foldl as F
 
 -- Operator ^ will be overridden
 import Prelude hiding ((^), sum)
+
+
+data V = V {-# UNPACK #-} !Double {-# UNPACK #-} !Double
+data T = T {-# UNPACK #-}!Double {-# UNPACK #-}!Int
+data T1 = T1 {-# UNPACK #-}!Int {-# UNPACK #-}!Double {-# UNPACK #-}!Double
+
+-- (^) operator from Prelude is just slow.
+(^) :: Double -> Int -> Double
+x ^ 1 = x
+x ^ n = x * (x ^ (n-1))
+{-# INLINE (^) #-}
 
 -- | /O(n)/ Range. The difference between the largest and smallest
 -- elements of a sample.
@@ -83,14 +91,19 @@ range = maximum' - minimum'
 
 maximum' :: F.Fold Double Double
 maximum' = F.Fold max (-1/0 :: Double) id where
+{-# INLINE minimum' #-}
+
 minimum' :: F.Fold Double Double
 minimum' = F.Fold min ( 1/0 :: Double) id where
+{-# INLINE maximum' #-}
 
 kbnSum' :: F.Fold Double KBNSum
 kbnSum' = F.Fold add zero id
+{-# INLINE kbnSum' #-}
 
 kbnSum :: F.Fold Double Double
 kbnSum = fmap kbn kbnSum'
+{-# INLINE kbnSum #-}
 
 
 -- | Compute expectation of function over for sample.
@@ -145,6 +158,7 @@ geometricMean :: F.Fold Double Double
 geometricMean = fmap exp (expectation log)
 {-# INLINE geometricMean #-}
 
+
 -- | Compute the /k/th central moment of a sample.  The central moment
 -- is also known as the moment about the mean.
 --
@@ -173,20 +187,14 @@ centralMoment a m
 --
 -- For samples containing many values very close to the mean, this
 -- function is subject to inaccuracy due to catastrophic cancellation.
-centralMoments :: (G.Vector v Double) => Int -> Int -> v Double -> (Double, Double)
-centralMoments a b xs
-    | a < 2 || b < 2 = (centralMoment a xs , centralMoment b xs)
-    | otherwise      = fini . G.foldl' go (V 0 0) $ xs
-  where go (V i j) x = V (i + d^a) (j + d^b)
+centralMoments :: Int -> Int -> Double  -> F.Fold Double (Double, Double)
+centralMoments a b m
+    | a < 2 || b < 2 = liftA2 (,) (centralMoment a m) (centralMoment b m)
+    | otherwise      = F.Fold go (T1 0 0 0) fini
+  where go (T1 n i j) x = T1 (n+1) (i + d^a) (j + d^b)
             where d  = x - m
-        fini (V i j) = (i / n , j / n)
-        m            = mean xs
-        n            = fromIntegral (G.length xs)
-{-# SPECIALIZE
-    centralMoments :: Int -> Int -> U.Vector Double -> (Double, Double) #-}
-{-# SPECIALIZE
-    centralMoments :: Int -> Int -> V.Vector Double -> (Double, Double) #-}
-
+        fini (T1 n i j) = (i / n' , j / n')
+            where n' = fromIntegral n
 -- | Compute the skewness of a sample. This is a measure of the
 -- asymmetry of its distribution.
 --
@@ -209,11 +217,9 @@ centralMoments a b xs
 --
 -- For samples containing many values very close to the mean, this
 -- function is subject to inaccuracy due to catastrophic cancellation.
-skewness :: (G.Vector v Double) => v Double -> Double
-skewness xs = c3 * c2 ** (-1.5)
-    where (c3 , c2) = centralMoments 3 2 xs
-{-# SPECIALIZE skewness :: U.Vector Double -> Double #-}
-{-# SPECIALIZE skewness :: V.Vector Double -> Double #-}
+skewness :: Double -> F.Fold Double Double
+skewness m = (\(c3, c2) -> c3 * c2 ** (-1.5)) <$> centralMoments 3 2 m
+
 
 -- | Compute the excess kurtosis of a sample.  This is a measure of
 -- the \"peakedness\" of its distribution.  A high kurtosis indicates
@@ -228,11 +234,8 @@ skewness xs = c3 * c2 ** (-1.5)
 --
 -- For samples containing many values very close to the mean, this
 -- function is subject to inaccuracy due to catastrophic cancellation.
-kurtosis :: (G.Vector v Double) => v Double -> Double
-kurtosis xs = c4 / (c2 * c2) - 3
-    where (c4 , c2) = centralMoments 4 2 xs
-{-# SPECIALIZE kurtosis :: U.Vector Double -> Double #-}
-{-# SPECIALIZE kurtosis :: V.Vector Double -> Double #-}
+kurtosis :: Double -> F.Fold Double Double
+kurtosis m = (\(c4, c2) -> c4 / (c2 * c2) - 3) <$> centralMoments 4 2 m
 
 -- $variance
 --
@@ -248,70 +251,60 @@ kurtosis xs = c4 / (c2 * c2) - 3
 -- Because of the need for two passes, these functions are /not/
 -- subject to stream fusion.
 
-data V = V {-# UNPACK #-} !Double {-# UNPACK #-} !Double
-
 -- | Maximum likelihood estimate of a sample's variance.  Also known
 -- as the population variance, where the denominator is /n/.
-variance :: (G.Vector v Double) => v Double -> Double
-variance samp
-    | n > 1     = robustSumVar (mean samp) samp / fromIntegral n
-    | otherwise = 0
-    where
-      n = G.length samp
-{-# SPECIALIZE variance :: U.Vector Double -> Double #-}
-{-# SPECIALIZE variance :: V.Vector Double -> Double #-}
+variance :: Double -> F.Fold Double Double
+variance m =
+    liftA2 (\s n -> if n > 1 then s / n else 0)
+           (robustSumVar m) F.genericLength
 
+
+
+robustSumVar :: Double -> F.Fold Double Double
+robustSumVar m = F.premap (square . subtract m) kbnSum
 
 -- | Unbiased estimate of a sample's variance.  Also known as the
 -- sample variance, where the denominator is /n/-1.
-varianceUnbiased :: (G.Vector v Double) => v Double -> Double
-varianceUnbiased samp
-    | n > 1     = robustSumVar (mean samp) samp / fromIntegral (n-1)
-    | otherwise = 0
-    where
-      n = G.length samp
-{-# SPECIALIZE varianceUnbiased :: U.Vector Double -> Double #-}
-{-# SPECIALIZE varianceUnbiased :: V.Vector Double -> Double #-}
+varianceUnbiased :: Double -> F.Fold Double Double
+varianceUnbiased m =
+    liftA2 (\s n -> if n > 1 then s / (n-1) else 0)
+           (robustSumVar m) F.genericLength
 
+{-
 -- | Calculate mean and maximum likelihood estimate of variance. This
 -- function should be used if both mean and variance are required
 -- since it will calculate mean only once.
-meanVariance ::  (G.Vector v Double) => v Double -> (Double,Double)
-meanVariance samp
-  | n > 1     = (m, robustSumVar m samp / fromIntegral n)
-  | otherwise = (m, 0)
-    where
-      n = G.length samp
-      m = mean samp
-{-# SPECIALIZE meanVariance :: U.Vector Double -> (Double,Double) #-}
-{-# SPECIALIZE meanVariance :: V.Vector Double -> (Double,Double) #-}
+-- meanVariance :: Double -> F.Fold Double (Double,Double)
+-- meanVariance m
+--   | n > 1     = (m, robustSumVar m samp / fromIntegral n)
+--   | otherwise = (m, 0)
+--     where
+--       n = G.length samp
+-- {-# SPECIALIZE meanVariance :: U.Vector Double -> (Double,Double) #-}
+-- {-# SPECIALIZE meanVariance :: V.Vector Double -> (Double,Double) #-}
 
 -- | Calculate mean and unbiased estimate of variance. This
 -- function should be used if both mean and variance are required
 -- since it will calculate mean only once.
-meanVarianceUnb :: (G.Vector v Double) => v Double -> (Double,Double)
-meanVarianceUnb samp
-  | n > 1     = (m, robustSumVar m samp / fromIntegral (n-1))
-  | otherwise = (m, 0)
-    where
-      n = G.length samp
-      m = mean samp
-{-# SPECIALIZE meanVarianceUnb :: U.Vector Double -> (Double,Double) #-}
-{-# SPECIALIZE meanVarianceUnb :: V.Vector Double -> (Double,Double) #-}
+-- meanVarianceUnb :: (G.Vector v Double) => v Double -> (Double,Double)
+-- meanVarianceUnb samp
+--   | n > 1     = (m, robustSumVar m samp / fromIntegral (n-1))
+--   | otherwise = (m, 0)
+--     where
+--       n = G.length samp
+--       m = mean samp
+-- {-# SPECIALIZE meanVarianceUnb :: U.Vector Double -> (Double,Double) #-}
+-- {-# SPECIALIZE meanVarianceUnb :: V.Vector Double -> (Double,Double) #-}
 
 -- | Standard deviation.  This is simply the square root of the
 -- unbiased estimate of the variance.
-stdDev :: (G.Vector v Double) => v Double -> Double
-stdDev = sqrt . varianceUnbiased
-{-# SPECIALIZE stdDev :: U.Vector Double -> Double #-}
-{-# SPECIALIZE stdDev :: V.Vector Double -> Double #-}
+stdDev :: Double -> F.Fold Double Double
+stdDev m = fmap sqrt $ varianceUnbiased m
 
 -- | Standard error of the mean. This is the standard deviation
 -- divided by the square root of the sample size.
-stdErrMean :: (G.Vector v Double) => v Double -> Double
-stdErrMean samp = stdDev samp / (sqrt . fromIntegral . G.length) samp
-{-# SPECIALIZE stdErrMean :: U.Vector Double -> Double #-}
-{-# SPECIALIZE stdErrMean :: V.Vector Double -> Double #-}
+stdErrMean :: Double -> F.Fold Double Double
+stdErrMean m = stdDev m / fmap sqrt F.genericLength
 
 robustSumVarWeighted :: (G.Vector v (Double,Double)) => v (Double,Double) -> V
 robustSumVarWeighted samp = G.foldl' go (V 0 0) samp
@@ -510,3 +503,4 @@ yielding to boxed returns and heap checks.
 -- * West, D.H.D. (1979) Updating mean and variance estimates: an
 --   improved method. /Communications of the ACM/
 --   22(9):532&#8211;535. <http://doi.acm.org/10.1145/359146.359153>
+-}

--- a/Statistics/Sample/Fold.hs
+++ b/Statistics/Sample/Fold.hs
@@ -117,6 +117,8 @@ expectation f = F.premap f kbnSum / F.genericLength
 -- fusion.
 mean :: F.Fold Double Double
 mean = kbnSum / F.genericLength
+{-# INLINE mean #-}
+
 
 -- | Arithmetic mean.  This uses Welford's algorithm to provide
 -- numerical stability, using a single pass over the sample data.
@@ -178,7 +180,8 @@ centralMoment a m
   where
     go x = (x-m) ^ a
     -- m    = mean xs
---
+{-# INLINE centralMoment #-}
+
 
 -- | Compute the /k/th and /j/th central moments of a sample.
 --
@@ -195,6 +198,9 @@ centralMoments a b m
             where d  = x - m
         fini (T1 n i j) = (i / n' , j / n')
             where n' = fromIntegral n
+{-# INLINE centralMoments #-}
+
+
 -- | Compute the skewness of a sample. This is a measure of the
 -- asymmetry of its distribution.
 --
@@ -219,6 +225,7 @@ centralMoments a b m
 -- function is subject to inaccuracy due to catastrophic cancellation.
 skewness :: Double -> F.Fold Double Double
 skewness m = (\(c3, c2) -> c3 * c2 ** (-1.5)) <$> centralMoments 3 2 m
+{-# INLINE skewness #-}
 
 
 -- | Compute the excess kurtosis of a sample.  This is a measure of
@@ -236,6 +243,8 @@ skewness m = (\(c3, c2) -> c3 * c2 ** (-1.5)) <$> centralMoments 3 2 m
 -- function is subject to inaccuracy due to catastrophic cancellation.
 kurtosis :: Double -> F.Fold Double Double
 kurtosis m = (\(c4, c2) -> c4 / (c2 * c2) - 3) <$> centralMoments 4 2 m
+{-# INLINE kurtosis #-}
+
 
 -- $variance
 --
@@ -257,11 +266,15 @@ variance :: Double -> F.Fold Double Double
 variance m =
     liftA2 (\s n -> if n > 1 then s / n else 0)
            (robustSumVar m) F.genericLength
+{-# INLINE variance #-}
+
 
 
 
 robustSumVar :: Double -> F.Fold Double Double
 robustSumVar m = F.premap (square . subtract m) kbnSum
+{-# INLINE robustSumVar #-}
+
 
 -- | Unbiased estimate of a sample's variance.  Also known as the
 -- sample variance, where the denominator is /n/-1.
@@ -269,6 +282,8 @@ varianceUnbiased :: Double -> F.Fold Double Double
 varianceUnbiased m =
     liftA2 (\s n -> if n > 1 then s / (n-1) else 0)
            (robustSumVar m) F.genericLength
+{-# INLINE varianceUnbiased #-}
+
 
 {-
 -- | Calculate mean and maximum likelihood estimate of variance. This

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,3 +1,5 @@
+module Main where
+
 import Data.Complex
 import Statistics.Sample
 import Statistics.Transform

--- a/statistics.cabal
+++ b/statistics.cabal
@@ -223,7 +223,7 @@ benchmark statistics-bench
   import:         bench-stanza
   type:           exitcode-stdio-1.0
   hs-source-dirs: benchmark bench-time
-  main-is:        bench.hs
+  main-is:        Main.hs
   Other-modules:  Bench
   build-depends:  tasty-bench >= 0.3
 

--- a/statistics.cabal
+++ b/statistics.cabal
@@ -101,6 +101,7 @@ library
     Statistics.Resampling
     Statistics.Resampling.Bootstrap
     Statistics.Sample
+    Statistics.Sample.Fold
     Statistics.Sample.Internal
     Statistics.Sample.Histogram
     Statistics.Sample.KernelDensity
@@ -142,6 +143,7 @@ library
                , vector-th-unbox
                , vector-binary-instances >= 0.2.1
                , data-default-class      >= 0.1.2
+               , foldl
 
   -- Older GHC
   if impl(ghc < 7.6)


### PR DESCRIPTION
_Very much a WIP, the code is written and benchmarked, but the comments haven't been updated, version bounds for the `foldl` package haven't been chosen, and there's plenty of mess - consider this a proof of concept for now._

Well I managed to thoroughly nerdsnipe myself with this. This work is based on my `foldl-statistics` package, which translated all the functions in `Statistics.Sample` to use the `foldl` package's `Fold` type many years ago.  This has a few benefits:

 - Statistics are no longer tied to the Vector package, any Foldable can be used as an input. Folds can also have their inputs contravariantly mapped and the output covariantly mapped, so projecting from more complex types into Double without producing intermediate vectors is simple:
   ```haskell
    data Foo = Foo {bar :: Double, baz :: Int}

    averageBars :: Fold Foo Double
    averageBars = F.premap bar average

   averageBazs :: Fold Foo Double
   averageBazs = F.premap (fromIntegral . baz) average
   ```
 - Statistics can be computed in parallel more easily, if you want to compute the `mean` over a several vectors, or slices of a vector in parallel, `kbnSum :: Fold Double KBNSum` can be applied to each part, and combined monoidally before performing a single division.
 - Statistics can be computed incrementally. This seems particularly useful in the `dataframes` package, where statistics can be computed on each column as it's parsed (this has the added benefit that Columns of Double's could potentially store their mean, which is passed to folds over unfiltered columns, making more statistics "one pass", if we ignore the parsing pass).
 - it makes clear in the types when multiple passes over the data are needed - Folds which need to know the mean take it as an argument.

This PR converts all functions in Statistics.Sample to use the new `Statistics.Sample.Fold` module. Across the board, things are either about the same speed, slightly faster  or slower (this seems to be more to do with how busy my machine is though), of significantly faster - `correlation` and `covariance` save between 40% and 50%, and I found an optimisation the custom `(^)` function which makes all the central moment calculations significantly faster:

## Results from benchmarks:

|Name                       | master Mean | foldl Mean | %of master| master 2*Stdev | foldl 2*Stdev |
|:--------------------------|---------:|---------:|----------:|------------:|------------:|
|All.sample.range           | 8262200  | 8169891  | 98.88     | 498610      | 452426      |
|All.sample.mean            | 26335827 | 24903906 | 94.56     | 1741032     | 2233392     |
|All.sample.meanWeighted    | 49147827 | 49967260 | 101.66    | 3310974     | 3697810     |
|All.sample.harmonicMean    | 6342874  | 6453201  | 101.73    | 431900      | 411892      |
|All.sample.geometricMean   | 47130517 | 47531176 | 100.85    | 3358250     | 3973606     |
|All.sample.variance        | 41127624 | 38427368 | 93.43     | 3461374     | 3347004     |
|All.sample.varianceUnbiased| 41193457 | 38872558 | 94.36     | 3349406     | 3730782     |
|All.sample.varianceWeighted| 57257397 | 60096997 | 104.95    | 3761462     | 5424648     |
|All.sample.pearson         | 99297216 | 59261547 | 59.68     | 7153452     | 3936702     |
|All.sample.covariance      | 71005322 | 39155200 | 55.14     | 5025584     | 3411858     |
|All.sample.correlation     | 99429296 | 59264257 | 59.60     | 7793264     | 4439162     |
|All.sample.covariance2     | 70466455 | 64897363 | 92.09     | 5640612     | 4228330     |
|All.sample.correlation2    | 98596923 | 76753466 | 77.84     | 7266128     | 6147440     |
|All.sample.stdDev          | 42555541 | 40379150 | 94.88     | 3659268     | 4008108     |
|All.sample.skewness        | 112101611| 48734301 | 43.47     | 9179452     | 4167406     |
|All.sample.kurtosis        | 124104443| 50724829 | 40.87     | 6640072     | 3372990     |
|All.sample.C.M. 2          | 71539257 | 52870776 | 73.90     | 6927224     | 2400496     |
|All.sample.C.M. 3          | 78216333 | 49357958 | 63.10     | 5512322     | 3578362     |
|All.sample.C.M. 4          | 85592968 | 50596264 | 59.11     | 7322466     | 3992384     |
|All.sample.C.M. 5          | 95427246 | 54429187 | 57.03     | 6733316     | 2168810     |


Master:
![Image](https://github.com/user-attachments/assets/b6e58b79-8417-43c7-9385-76bb2a9884a2)

Foldl:
![Image](https://github.com/user-attachments/assets/fe1fa201-3b8f-433a-a19e-a58176d3cd9b)