### PR TITLE
Make exponentiation significantly faster

### DIFF
--- a/Statistics/Sample.hs
+++ b/Statistics/Sample.hs
@@ -453,12 +453,6 @@ pair va vb
 
 -- (^) operator from Prelude is just slow.
 (^) :: Double -> Int -> Double
-x ^ 1 = x
-x ^ 2 = x * x
-x ^ 3 = x * x * x
-x ^ 4 = (x * x) * (x * x)
-x ^ 5 = (x * x) * x * (x * x)
--- x ^ n = x * (x ^ (n-1))
 x0 ^ n0 = go (n0-1) x0 where
     go 0 !acc = acc
     go n  acc = go (n-1) (acc*x0)

--- a/Statistics/Sample.hs
+++ b/Statistics/Sample.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE BangPatterns #-}
 -- |
 -- Module    : Statistics.Sample
 -- Copyright : (c) 2008 Don Stewart, 2009 Bryan O'Sullivan
@@ -453,7 +454,14 @@ pair va vb
 -- (^) operator from Prelude is just slow.
 (^) :: Double -> Int -> Double
 x ^ 1 = x
-x ^ n = x * (x ^ (n-1))
+x ^ 2 = x * x
+x ^ 3 = x * x * x
+x ^ 4 = (x * x) * (x * x)
+x ^ 5 = (x * x) * x * (x * x)
+-- x ^ n = x * (x ^ (n-1))
+x0 ^ n0 = go (n0-1) x0 where
+    go 0 !acc = acc
+    go n  acc = go (n-1) (acc*x0)
 {-# INLINE (^) #-}
 
 -- don't support polymorphism, as we can't get unboxed returns if we use it.


### PR DESCRIPTION
From #220, make the `(^)` function significantly faster - it does this two ways, by unrolling common low exponents (1-5), which allows GHC to inline the full set of multiplications, and in cases above 5, it uses a tail recursive loop, which is much faster than the non-tail recursive definition that's been in hiding in this package for over a decade (it probably is faster than Prelude's definition, but it's not fast).

Benchmarks, adding the 10th and 20th central moment to demonstrate the effect of the loop (I'm sure _someone_ must care about that statistic...). I've only included benchmarks that actually call `(^)`

```csv
                   , master   , unrolled ,            , master      , unrolled
Name               , Mean (ps), Mean (ps), % of master, 2*Stdev (ps), 2*Stdev (ps)
All.sample.skewness, 112217871,  48159448,       42.91,     10580706, 3933644
All.sample.kurtosis, 125990136,  51025634,       40.49,      7770772, 3650532
All.sample.C.M. 2  ,  71661035,  45683325,       63.74,      6811708, 4477812
All.sample.C.M. 3  ,  78805029,  43542919,       55.25,      7553062, 3881564
All.sample.C.M. 4  ,  85555419,  45128808,       52.74,      8290264, 4030818
All.sample.C.M. 5  ,  94791943,  44017114,       46.43,      7973198, 4154740
All.sample.C.M. 10 , 136170214,  76725390,       56.34,     13295868, 6833108
All.sample.C.M. 20 , 218253906, 106618505,       48.85,     15665576, 7769680
```